### PR TITLE
Export aleo-sdk types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
 import { Account } from "./account";
 import { NodeConnection } from "./node_connection";
-
-export { Account, NodeConnection };
+import { Address, PrivateKey, Signature, ViewKey } from "@entropy1729/aleo-sdk";
+export { Account, NodeConnection, PrivateKey, Signature, ViewKey, Address};


### PR DESCRIPTION
## Changes:
- Directly export aleo-sdk types to use as part of the API.